### PR TITLE
Make screen eachtime after

### DIFF
--- a/aquality-selenium-template-cucumber/pom.xml
+++ b/aquality-selenium-template-cucumber/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>aquality-selenium-template-project</artifactId>
         <groupId>com.github.aquality-automation</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aquality-selenium-template-cucumber</artifactId>
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-selenium-template</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/hooks/ScreenshotHooks.java
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/hooks/ScreenshotHooks.java
@@ -17,8 +17,6 @@ public class ScreenshotHooks {
 
     @After(order = 1)
     public void takeScreenshot(Scenario scenario) {
-        if (scenario.isFailed()) {
-            scenario.attach(screenshotProvider.takeScreenshot(), "image/png", "screenshot");
-        }
+        scenario.attach(screenshotProvider.takeScreenshot(), "image/png", "screenshot.png");
     }
 }

--- a/aquality-selenium-template-cucumber/src/test/resources/aqualityTracking.json
+++ b/aquality-selenium-template-cucumber/src/test/resources/aqualityTracking.json
@@ -1,10 +1,10 @@
 {
   "enabled": false,
-  "host": "{aquality_tracking_address}",
-  "token": "{api_token}",
-  "projectId": 0,
+  "host": "{protocol_host_and_port}",
+  "token": "{generated_api_token}",
+  "projectId": 1,
   "executor": "Azure DevOps",
-  "suiteName": "Demo",
+  "suiteName": "{project_suite_name_to_import}",
   "buildName": "1.0.0",
   "environment": "Stage",
   "attachmentsDirectory": "target/attachments"

--- a/aquality-selenium-template/pom.xml
+++ b/aquality-selenium-template/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>aquality-selenium-template-project</artifactId>
         <groupId>com.github.aquality-automation</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>aquality-selenium-template</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.aquality-automation</groupId>
     <artifactId>aquality-selenium-template-project</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-selenium</artifactId>
-            <version>2.2.0</version>
+            <version>2.5.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
to quick demo of screenshot attachments made changes to make screenshots each time after the test (not only for failed)

as aquality tracking uses extension in the fileName to decide how to show the file preview, added '.png' to the screenshot name
in the aquality settings changed:
 - placeholders' text of dynamic variables
 - projectId configured to 1 as default as 0 is not allowed