### PR TITLE
New scenarios for clown api

### DIFF
--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/features/DemoApi.feature
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/features/DemoApi.feature
@@ -70,3 +70,4 @@ Feature: Demo API
       And the 'response' matches json schema 'users/UserResponse' clone
       And the 'url' has the value saved as 'user URL' in the 'response' clone
       And the 'response' time is less than or equal to 5 seconds clone
+

--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/features/DemoApi.feature
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/features/DemoApi.feature
@@ -35,3 +35,38 @@ Feature: Demo API
       And the 'response' matches json schema 'users/UserResponse'
       And the 'url' has the value saved as 'user URL' in the 'response'
       And the 'response' time is less than or equal to 5 seconds
+
+  Scenario: GET user info clone
+    When I send GET '/users/aqualityAutomation' request to github with saving the 'response' clone
+    Then the status code of the 'response' is '200' clone
+      And the 'response' matches json schema 'users/UserResponse' clone
+      And the 'login' is 'aqualityAutomation' in the 'response' clone
+      And the 'type' is 'User' in the 'response' clone
+      And the 'response' time is less than or equal to 5 seconds clone
+    When I save the user from the 'response' as 'user1' clone
+      And I send GET '/users/aquality-automation' request to github with saving the 'response2' clone
+      And I save the user from the 'response2' as 'user2' clone
+    Then User 'user1' is different from the user 'user2' clone
+
+  Scenario: GET organization info clone
+    When I send GET '/users/aquality-automation' request to github with saving the 'response' clone
+    Then the status code of the 'response' is '200' clone
+      And the 'response' matches json schema 'users/UserResponse' clone
+      And the 'login' is 'aquality-automation' in the 'response' clone
+      And the 'type' is 'Organization' in the 'response' clone
+      And the 'id' is 50261201 in the 'response' clone
+      And the 'response' time is less than or equal to 5 seconds clone
+
+  Scenario: GET users info clone
+    When I send GET '/users' request to github with saving the 'users response' clone
+    Then the status code of the 'users response' is '200' clone
+      And the 'users response' matches json schema 'users/UsersResponse' clone
+      And the 'users response' time is less than or equal to 5 seconds clone
+      And the '.' array has size less than or equal to 30 in the 'users response' clone
+      And the '.' array is ordered ascending by 'id' in the 'users response' clone
+    When I extract the '[0].url' from the 'users response' with saving it as 'user URL' clone
+      And I send GET request to github endpoint saved as 'user URL' with saving the 'response' clone
+    Then the status code of the 'response' is '200' clone
+      And the 'response' matches json schema 'users/UserResponse' clone
+      And the 'url' has the value saved as 'user URL' in the 'response' clone
+      And the 'response' time is less than or equal to 5 seconds clone

--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/common/ResponseCloneSteps.java
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/common/ResponseCloneSteps.java
@@ -1,0 +1,84 @@
+package aquality.selenium.template.cucumber.stepdefinitions.api.common;
+
+import aquality.selenium.template.cucumber.utilities.ScenarioContext;
+import aquality.selenium.template.utilities.FileHelper;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.qameta.allure.Allure;
+import io.restassured.response.Response;
+import lombok.SneakyThrows;
+import org.testng.Assert;
+
+import javax.inject.Inject;
+import java.io.FileInputStream;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static aquality.selenium.template.cucumber.utilities.SortingUtilities.sort;
+import static aquality.selenium.template.cucumber.utilities.SortingUtilities.sortAsNumbers;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.*;
+
+public class ResponseCloneSteps {
+    private static final String SCHEMA_PATH_TEMPLATE = "jsonschemas/%s.json";
+    private final ScenarioContext scenarioContext;
+
+    @Inject
+    public ResponseCloneSteps(ScenarioContext scenarioContext) {
+        this.scenarioContext = scenarioContext;
+    }
+
+    @Then("the status code of the '{response}' is '{int}' clone")
+    public void statusCodeOfResponseIs(Response response, int statusCode) {
+        response.then().statusCode(statusCode);
+    }
+
+    @Then("the {string} has the value saved as '{contextKey}' in the '{response}' clone")
+    @Then("the {string} is {string} in the '{response}' clone")
+    @Then("the {string} is {int} in the '{response}' clone")
+    public void fieldInResponseIs(String fieldName, Object expectedValue, Response response) {
+        response.then().body(fieldName, equalTo(expectedValue));
+    }
+
+    @Then("the {string} array has size less than or equal to {int} in the '{response}' clone")
+    public void fieldArrayInResponseHasSizeLessThanOrEqualTo(String fieldName, int maxSize, Response response) {
+        response.then().body(fieldName, hasSize(lessThanOrEqualTo(maxSize)));
+    }
+
+    @Then("the {string} array is ordered {isAscendingOrder} by {string} in the '{response}' clone")
+    public void fieldArrayInResponseIsSortedBy(String path, boolean isAscendingOrder, String fieldName, Response response) {
+        List<JsonNode> nodeList = response.then().extract().body().jsonPath().getList(path, JsonNode.class);
+        if (nodeList == null || nodeList.isEmpty()) {
+            throw new IllegalArgumentException("Cannot check order on null or empty collection clone");
+        }
+        List<String> actualOrder = nodeList.stream().map(node -> node.get(fieldName).toString()).collect(Collectors.toList());
+        List<String> expectedOrder = nodeList.get(0).get(fieldName).isNumber()
+                ? sortAsNumbers(actualOrder, isAscendingOrder)
+                : sort(actualOrder, isAscendingOrder);
+        Assert.assertEquals(actualOrder, expectedOrder,
+                format("%s items must be sorted by %s in correct order. %nExpected:\t %s %n Actual:\t %s%n",
+                        path, fieldName, expectedOrder, actualOrder));
+    }
+
+    @Then("the '{response}' matches json schema {string} clone")
+    @SneakyThrows
+    public void responseMatchesJsonSchema(Response response, String schemaName) {
+        String pathToSchema = format(SCHEMA_PATH_TEMPLATE, schemaName);
+        Allure.addAttachment("json schema",
+                new FileInputStream(FileHelper.getResourceFileByName(pathToSchema)));
+        response.then().body(matchesJsonSchemaInClasspath(pathToSchema));
+    }
+
+    @When("I extract the {string} from the '{response}' with saving it as {string} clone")
+    public void extractAndSave(String path, Response response, String contextKey) {
+        scenarioContext.add(contextKey, response.then().extract().path(path));
+    }
+
+    @Then("the '{response}' time is less than or equal to {long} seconds clone")
+    public void responseTimeIsLessOrEqualTo(Response response, long seconds) {
+        response.then().time(lessThanOrEqualTo(seconds), TimeUnit.SECONDS);
+    }
+}

--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/github/RequestCloneSteps.java
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/github/RequestCloneSteps.java
@@ -1,0 +1,25 @@
+package aquality.selenium.template.cucumber.stepdefinitions.api.github;
+
+import aquality.selenium.template.cucumber.utilities.ScenarioContext;
+import io.cucumber.java.en.When;
+import io.restassured.response.Response;
+
+import javax.inject.Inject;
+
+import static aquality.selenium.template.utilities.RequestSpecifications.commonGiven;
+
+public class RequestCloneSteps {
+    private final ScenarioContext scenarioContext;
+
+    @Inject
+    public RequestCloneSteps(ScenarioContext scenarioContext) {
+        this.scenarioContext = scenarioContext;
+    }
+
+    @When("I send GET '{endpoint}' request to github with saving the '{responseKey}' clone")
+    @When("I send GET request to github endpoint saved as '{contextKey}' with saving the '{responseKey}' clone")
+    public void sendGetRequestToGitHubAndSaveResponse(String endpoint, String contextKey) {
+        Response response = commonGiven().when().get(endpoint);
+        scenarioContext.add(contextKey, response);
+    }
+}

--- a/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/github/UserCloneSteps.java
+++ b/aquality-selenium-template-cucumber/src/test/java/aquality/selenium/template/cucumber/stepdefinitions/api/github/UserCloneSteps.java
@@ -1,0 +1,29 @@
+package aquality.selenium.template.cucumber.stepdefinitions.api.github;
+
+import aquality.selenium.template.cucumber.utilities.ScenarioContext;
+import aquality.selenium.template.models.User;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.response.Response;
+import org.testng.Assert;
+
+import javax.inject.Inject;
+
+public class UserCloneSteps {
+    private final ScenarioContext scenarioContext;
+
+    @Inject
+    public UserCloneSteps(ScenarioContext scenarioContext) {
+        this.scenarioContext = scenarioContext;
+    }
+
+    @When("I save the user from the '{response}' as {string} clone")
+    public void saveTheUserFromTheResponse(Response response, String key) {
+        scenarioContext.add(key, response.as(User.class));
+    }
+
+    @Then("User '{contextKey}' is different from the user '{contextKey}' clone")
+    public void userUserIsDifferentFromTheUserUser(User user1, User user2) {
+        Assert.assertNotEquals(user1, user2, "Users should not be equal");
+    }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added new scenarios for clown API testing, including user, organization, and GitHub users info.
- New Feature: Introduced step definitions for API response validation with various checks like status codes, field values, sorting, and JSON schema validation.
- New Feature: Implemented `RequestCloneSteps` for sending GET requests to GitHub API and saving responses.
- New Feature: Created `UserCloneSteps` for handling user cloning in GitHub API, enabling user comparison and extraction.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->