### PR TITLE
Include testNG project structure into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=aquality-automation_aquality-selenium-java-template&metric=alert_status)](https://sonarcloud.io/dashboard?id=aquality-automation_aquality-selenium-java-template)
 [![Allure report](https://github.com/aquality-automation/aquality-selenium-java-template/actions/workflows/test-with-allure-report.yml/badge.svg)](https://aquality-automation.github.io/aquality-selenium-java-template/)
 
+# This template provides example projects for TestNG and Cucumber. To use it, you need to delete the unused module.
+# The Allure report is also used. If you don't need it, also delete it from the code.
+
 # Aquality Selenium Template Project
 Template for [aquality-selenium-java](https://github.com/aquality-automation/aquality-selenium-java) library.
 
@@ -18,6 +21,10 @@ Template for [aquality-selenium-java](https://github.com/aquality-automation/aqu
   - **runners/**: Cucumber test runners
   - **stepdefinitions/**: step definition classes
   - **transformations/**: Cucumber [data transformations](https://cucumber.io/docs/cucumber/configuration/)
+- **aquality-selenium-template-testng** - TestNG implementation of the tests
+  - **steps/**: step classes
+  - **utilities/**: utils for testNG, such as JsonDataProvider and ModuleFactory
+  - **tests/**: classes with test methods
 
 ### Configuration
 [settings.json](https://github.com/aquality-automation/aquality-selenium-java-template/blob/master/aquality-selenium-template/src/main/resources/settings.json) file contains settings of Aquality Selenium library. Additional information you can find [here](https://github.com/aquality-automation/aquality-selenium-java/wiki/Overview-(English)).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Allure report](https://github.com/aquality-automation/aquality-selenium-java-template/actions/workflows/test-with-allure-report.yml/badge.svg)](https://aquality-automation.github.io/aquality-selenium-java-template/)
 
 # This template provides example projects for TestNG and Cucumber. To use it, you need to delete the unused module.
+
 # The Allure report is also used. If you don't need it, also delete it from the code.
+
 
 # Aquality Selenium Template Project
 Template for [aquality-selenium-java](https://github.com/aquality-automation/aquality-selenium-java) library.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 # Aquality Selenium Template Project
 Template for [aquality-selenium-java](https://github.com/aquality-automation/aquality-selenium-java) library.
 
-### Project structure
+## Project structure
 - **aquality-selenium-template** - project related part with PageObjects, models and utilities
   - **configuration/**: classes that used to fetch project config from [src/main/resources/environment](https://github.com/aquality-automation/aquality-selenium-java-template/blob/master/aquality-selenium-template/src/main/resources/environment) folder
   - **forms/**: Page Objects
@@ -28,19 +28,19 @@ Template for [aquality-selenium-java](https://github.com/aquality-automation/aqu
   - **utilities/**: utils for testNG, such as JsonDataProvider and ModuleFactory
   - **tests/**: classes with test methods
 
-### Configuration
+## Configuration
 [settings.json](https://github.com/aquality-automation/aquality-selenium-java-template/blob/master/aquality-selenium-template/src/main/resources/settings.json) file contains settings of Aquality Selenium library. Additional information you can find [here](https://github.com/aquality-automation/aquality-selenium-java/wiki/Overview-(English)).
 
 [allure.properties](https://github.com/aquality-automation/aquality-selenium-java-template/blob/master/aquality-selenium-template/src/main/resources/allure.properties) is a part of Allure Report configuration. See details [here](https://docs.qameta.io/allure/).   
 
-### Tests execution
+## Tests execution
 Scenarios from feature files can be executed with TestNG plugin for IDE (Intellij Idea, Eclipse)
 or with Maven command ```mvn clean test``` where you can specify all necessary arguments.
 
 If executed with Maven, tests will be run in ```4``` threads. To change the amount of threads add ```-Ddata.provider.thread.count``` property to the command.
 E.g. ```mvn clean test -Ddata.provider.thread.count=10```.
 
-### Reporting 
+## Reporting 
 Allure Framework is used as a reporting tool. Report data will be placed in ```target/allure-results/``` folder (you can change it in ```allure.properties``` file).
 
 Run maven command ```mvn allure:serve``` to build and open report in web browser. To generate report in CI use corresponding plugin for your system.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
    - Updated README.md to include instructions for deleting unused modules and removing the Allure report if not needed.
    - Added new directories and content descriptions under the `aquality-selenium-template-testng` section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->